### PR TITLE
Update snitcher script compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.css.map
+tmp/*
+unified.*

--- a/snitcher.sh
+++ b/snitcher.sh
@@ -6,6 +6,7 @@ set -e # Bail if anything goes wrong
 URL="${URL:-https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts}"
 NAME="${NAME:-Steven Black}"
 PREFIX="${PREFIX:-unified}"
+OS="${OS:-$(uname)}"
 
 working_file="$PREFIX.working"
 
@@ -17,7 +18,30 @@ local now="$(date -Iseconds -u) UTC"
 curl --silent "$URL" \
     | awk '$1 == "0.0.0.0" && $2 != "0.0.0.0" {printf "    \"%s\",\n", $2}' \
     | sort > "$working_file"
-split -d --number l/2 "$working_file" part-
+
+# Split the file in half to avoid Little Snitch rule group
+# size limit of 200k entries.
+if [ "$OS" = "Darwin" ]; then
+
+    # On macOS, check if 'gsplit' is available so that we can
+    # use the same arguments as Linux. Otherwise, use the
+    # macos version of 'split' which has different arguments
+    # but produces a similar result.
+    if command -v gsplit2 > /dev/null; then
+        gsplit -d --number l/2 "$working_file" part-
+
+    else
+        # The macos version of 'split' takes different arguments
+        # but still produces two files of roughly equal size. The
+        # only difference is that the suffix of the files starts
+        # with '-aa' instead of '-00').
+        split -l $(expr $(wc -l < "$working_file") / 2 + 1) "$working_file" part-
+    fi
+else
+    # On other systems, use 'split'
+    split -d --number l/2 "$working_file" part-
+fi
+
 rm "$working_file"
 
 for part in part-*; do


### PR DESCRIPTION
This pull request updates the snitcher script to add OS detection for cross-platform compatibility when splitting files. It uses 'gsplit' on macOS if available, otherwise it uses the macOS version of 'split' with equivalent arguments. Additionally, the .gitignore file is updated to exclude 'unified.*' unified build outputs and 'tmp*' working files.

### About gsplit

`gsplit` is the GNU version of the standard `split` command. It's part of the GNU core utilities package, which is standard on Linux systems. On macOS, the built-in split command is a BSD version, which works differently.

Here are the links to the official installation instructions for GNU core utilities:

1. [Homebrew](https://brew.sh/): After installing Homebrew, you can install coreutils with `brew install coreutils`.

2. [MacPorts](https://www.macports.org/install.php): After installing MacPorts, you can install coreutils with `sudo port install coreutils`.

3. [From Source](http://www.gnu.org/software/coreutils/): This is the official page of the GNU core utilities. You can find the source code and the installation instructions here. Please note that building from source can be complex and may require additional software.


### Alternative implementation

Here's a normalized version of the split logic. It's DRYer but less readable. 

```bash
# Split the file in half to avoid Little Snitch rule group
# size limit of 200k entries.
split_command="split"
split_args="-d --number l/2 \"$working_file\" part-"

if [ "$OS" = "Darwin" ]; then
    # On macOS, check if 'gsplit' is available so that we can
    # use the same arguments as Linux. Otherwise, use the
    # macOS version of 'split' which has different arguments
    # but produces a similar result.
    if command -v gsplit > /dev/null; then
        split_command="gsplit"
    else
        # The macOS version of 'split' takes different arguments
        # but still produces two files of roughly equal size. The
        # only difference is that the suffix of the files starts
        # with '-aa' instead of '-00').
        split_args="-l $(expr $(wc -l < \"$working_file\") / 2 + 1) \"$working_file\" part-"
    fi
fi

# Execute the split command
eval "$split_command $split_args"
```
